### PR TITLE
Fix bug when parsing partition by struct statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v1.4 [24-Aug-2023]
+### Fixed
+- Fixed a bug when parsing `PARTITION BY` statements where the `STRUCT` token was in a different line 
+without blank spaces.
+- Commented lines (starting with double dashes --) are ignored.
+
 ## v1.3 [08-Aug-2023]
 ### Fixed
 - Fixed a bug when parsing `JOIN` statements where the table/stream had multiple spaces

--- a/parser/ksql_parser.py
+++ b/parser/ksql_parser.py
@@ -38,7 +38,7 @@ class KSQLParser:
       curr_line = lines[line_start]
       
       while not(";" in curr_line or "EMIT" in curr_line) and line_start+1 < max_lines:
-        out = out + curr_line.strip()
+        out = out + " " + curr_line.strip()
         line_start += 1
         curr_line = lines[line_start]
       
@@ -52,6 +52,10 @@ class KSQLParser:
 
     for line in lines:
       lowerline = line.lower().strip()
+
+      # ignoring commented lines
+      if lowerline.startswith("--"):
+        continue
 
       # ignoring INSERT statements
       if re.search("insert into", lowerline) is not None:


### PR DESCRIPTION
# PR Description

* Fixes a bug when parsing PARTITION BY statements if followed by a STRUCT keyword without a blank space.
```
PARTITION BY
     STRUCT (....)
```

* Ignores commented lines
```
-- comments are now ignored by the parser
```
